### PR TITLE
Users/israth/multi tenant support

### DIFF
--- a/src/service/Common/Constants.cs
+++ b/src/service/Common/Constants.cs
@@ -21,6 +21,7 @@ namespace Microsoft.FeatureFlighting.Common
             public const string FEATURE_ADD_ENABLED_CONTEXT = "AddEnabledContext";
             public const string FLIGHT_ADD_RESULT_CONTEXT_HEADER = "X-add-result-context";
             public const string ALL = "*";
+            public const string TENANT_FLAG_DELIMITER = "__";
 
             public struct Environment
             {

--- a/src/service/Domain/Domain/ValueObjects/Condition.cs
+++ b/src/service/Domain/Domain/ValueObjects/Condition.cs
@@ -159,7 +159,7 @@ namespace Microsoft.FeatureFlighting.Core.Domain.ValueObjects
             {
                 foreach (Stage updatedStage in updatedStages)
                 {
-                    areStagesUpdated = Stages.First(stage => stage.Id == updatedStage.Id).TryUpdate(updatedStage);
+                    areStagesUpdated = areStagesUpdated || Stages.First(stage => stage.Id == updatedStage.Id).TryUpdate(updatedStage);
                 }
             }
 

--- a/src/service/Domain/Services/FeatureFlagEvaluator.cs
+++ b/src/service/Domain/Services/FeatureFlagEvaluator.cs
@@ -10,6 +10,7 @@ using Microsoft.FeatureFlighting.Common.Config;
 using Microsoft.FeatureFlighting.Core.Evaluation;
 using System.Collections.ObjectModel;
 using System.Collections.Concurrent;
+using System;
 
 namespace Microsoft.FeatureFlighting.Core
 {
@@ -45,7 +46,7 @@ namespace Microsoft.FeatureFlighting.Core
             Dictionary<string, List<string>> featureToTenantMap = new Dictionary<string, List<string>>(); 
             foreach (var feature in features)
             {
-                var featureSplit = feature.Split(':');
+                var featureSplit = feature.Split(new string[] { Constants.Flighting.TENANT_FLAG_DELIMITER }, StringSplitOptions.None);
                 // For Verge:Snap where Verge is Tenant Name and Snap is the Feature Name
                 if (featureSplit.Length == 2)   
                 {
@@ -76,7 +77,7 @@ namespace Microsoft.FeatureFlighting.Core
 
                 foreach (var featureEvalResult in featureEvaluationResults)
                 {
-                    var featureKey = isDefaultTenant ? featureEvalResult.Key : $"{tenantConfiguration.Name}:{featureEvalResult.Key}";
+                    var featureKey = isDefaultTenant ? featureEvalResult.Key : $"{tenantConfiguration.Name}{Constants.Flighting.TENANT_FLAG_DELIMITER}{featureEvalResult.Key}";
                     if (!results.ContainsKey(featureKey))
                     {
                         results.Add(featureKey, featureEvalResult.Value);


### PR DESCRIPTION
Added cross tenant feature flighting evaluation support. 
If you add tenant configuration in the format of Tenant:FeatureFlightName, it will look for the feature flight in the specified tenant rather than the default tenant. 
For example, if you provide the name as TEST:TestFlag, it will search if the feature flag named TestFlag is present in the tenant TEST or not. 
