### PR TITLE
Bug Fixes and App Configuration MI changes

### DIFF
--- a/src/service/Domain/CoreModule.cs
+++ b/src/service/Domain/CoreModule.cs
@@ -221,6 +221,10 @@ namespace Microsoft.FeatureFlighting.Core
                 .As<QueryHandler<GetFeatureFlightsQuery, IEnumerable<FeatureFlightDto>>>()
                 .SingleInstance();
 
+            builder.RegisterType<GetFeatureNamesQueryHandler>()
+                .As<QueryHandler<GetFeatureNamesQuery, IEnumerable<string>>>()
+                .SingleInstance();
+
             builder.RegisterType<GetRegisteredTenantsQueryHandler>()
                 .As<QueryHandler<GetRegisteredTenantsQuery, IEnumerable<TenantConfiguration>>>()
                 .SingleInstance();

--- a/src/service/Infrastructure/AppConfig/AzureConfigurationClientProvider.cs
+++ b/src/service/Infrastructure/AppConfig/AzureConfigurationClientProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Azure.Core;
 using Azure.Data.AppConfiguration;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.FeatureFlighting.Infrastructure.AppConfig
@@ -31,9 +32,8 @@ namespace Microsoft.FeatureFlighting.Infrastructure.AppConfig
                 options.Retry.MaxRetries = 10;
                 options.Retry.Delay = TimeSpan.FromSeconds(1);
 
-                string connectionStringLocation = _configuration["AppConfiguration:ConnectionStringLocation"];
-                string connectionString = _configuration[connectionStringLocation];
-                _configurationClient = new ConfigurationClient(connectionString, options);
+                string appConfigUri = _configuration["AzureAppConfigurationUri"];
+                _configurationClient = new ConfigurationClient(new Uri(appConfigUri), new DefaultAzureCredential(), options);
                 return _configurationClient;
 
             }


### PR DESCRIPTION
**Bug Fix for /api/v1/Evaluate endpoint**

In CoreModule.cs,
Earlier since the GetFeatureNamesQueryHandler was not registered, we were getting 500 when we hit this API. 
Now, the GetFeatureNamesQueryHandler is registered.


**MI Changes for App Config**

In AzureConfigurationClientProvider.cs,
Earlier, we were using the App Configuration connection string to create configuration client.
Now, we use DefaultAzureCredential, since we make use of MI
